### PR TITLE
Fix syntax error in picom.conf

### DIFF
--- a/etc/picom.conf
+++ b/etc/picom.conf
@@ -30,7 +30,7 @@ shadow-opacity = 0.5;
 	"! name~=''",
 # 	#"name = 'Notification'",
 # 	"x = 0 && y = 0 && override_redirect = true",
-	"name ?= 'GNUstep'",
+	"name ?= 'GNUstep'"
 # 	#"name != 'xlogin'",
 # 	"class_g *?= 'qiv'"
 # 	#"class_g = 'VirtualBox'",


### PR DESCRIPTION
The last value in the array should not have a trailing comma or it will cause a syntax error and picom will crash